### PR TITLE
Manifest and services.yaml

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: home-assistant/actions/hassfest@master

--- a/custom_components/palazzetti/manifest.json
+++ b/custom_components/palazzetti/manifest.json
@@ -7,5 +7,6 @@
       "@BoubourSe"
   ],
   "version": "0.1.0",
+  "iot_class": "local_polling",
   "requirements": []  
 }

--- a/custom_components/palazzetti/manifest.json
+++ b/custom_components/palazzetti/manifest.json
@@ -6,5 +6,6 @@
   "codeowners": [
       "@BoubourSe"
   ],
+  "version": "0.1.0",
   "requirements": []  
 }

--- a/custom_components/palazzetti/services.yaml
+++ b/custom_components/palazzetti/services.yaml
@@ -1,2 +1,21 @@
 set_parms:
   name: Set parameters
+  description: The parameters for controlling the stove.
+  fields:
+    SETP:
+      name: Set point
+      description: Set temperature target (integer).
+    PWR:
+      name: Power
+      description: The maximum power allowed while trying to achieve the set point (integer from 1 to 5).
+    RFAN:
+      name: Room fan
+      description: The level of the integrated room fan (if exists on your stove) (integer from 1 to 5 or string off/auto/high).
+    STATUS:
+      name: Stove status
+      description: Start or stop the stove (string on/off).
+      selector:
+        select:
+          options:
+            - "on"
+            - "off"

--- a/custom_components/palazzetti/services.yaml
+++ b/custom_components/palazzetti/services.yaml
@@ -1,0 +1,2 @@
+set_parms:
+  name: Set parameters


### PR DESCRIPTION
This PR does the following:

1. Adds `hassfest.yaml` which defines a github workflow that validates the integration.
2. Adds a `services.yaml` file to pass validation.
3. Updates the manifst file to add a version number and `iot_class` to pass validation.

With these updates in place the integration now works again and the error message "Integration 'palazzetti' not found." does not show in the logs anymore.

Closes #8 